### PR TITLE
Bump Dockerfile base OS from Debian Buster to Bullseye, Node 16 to 20

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,11 @@ The scenario show page uses a server-side-to-client-side data handoff rather tha
 ### Testing Stack
 
 RSpec with Capybara (feature tests), FactoryBot (`spec/factories/`), Shoulda Matchers, and SimpleCov. Test files mirror `app/` under `spec/`.
+
+## GitHub Workflow
+
+Use the `hub` CLI (not `gh`) for all GitHub operations such as opening pull requests:
+
+```bash
+hub pull-request --draft -m "Title" -m "Body"
+```

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,11 +1,11 @@
-FROM ruby:2.7.7-slim-buster
+FROM ruby:2.7.7-slim-bullseye
 
 #Install dependencies as root
 RUN apt-get update
 RUN apt-get install -y build-essential patch ruby-dev zlib1g-dev liblzma-dev libpq-dev curl
 
 #Install npm/yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g yarn
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,11 +1,11 @@
-FROM ruby:2.7.7-slim-buster
+FROM ruby:2.7.7-slim-bullseye
 
 #Install dependencies as root
 RUN apt-get update
 RUN apt-get install -y build-essential patch ruby-dev zlib1g-dev liblzma-dev libpq-dev curl
 
 #Install npm/yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g yarn
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM ruby:2.7.7-slim-buster
+FROM ruby:2.7.7-slim-bullseye
 
 #Install dependencies as root
 RUN apt-get update
@@ -9,7 +9,7 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app
 
 #Install npm/yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g yarn
 


### PR DESCRIPTION
## Summary

- Upgrades all three Dockerfiles (`base`, `development`, `production`) from `ruby:2.7.7-slim-buster` (Debian 10, EOL) to `ruby:2.7.7-slim-bullseye` (Debian 11) for a supported OS with current security patches
- Stays on Bullseye rather than Bookworm (Debian 12) to avoid OpenSSL 3.x compatibility issues with Ruby 2.7
- Bumps NodeSource script from `setup_16.x` (Node 16, EOL) to `setup_20.x` (Node 20 LTS)

## Test plan

- [x] Run `./go build` to confirm images build successfully on the new base
- [x] Run `./go test` to confirm the full RSpec suite passes
- [x] Run `./go start` and smoke-test the app at http://localhost:3001/