### PR TITLE
Add version_dates docs, bump Postgres to 16, and update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,10 @@ The scenario show page uses a server-side-to-client-side data handoff rather tha
 
 RSpec with Capybara (feature tests), FactoryBot (`spec/factories/`), Shoulda Matchers, and SimpleCov. Test files mirror `app/` under `spec/`.
 
+## Dockerfile Changes
+
+Test plans for Dockerfile changes do not need to include steps for building the image or running the test suite — CI handles both automatically on every PR. The test plan only needs to cover anything CI cannot verify, such as confirming the app starts correctly locally or checking that a new system dependency is available inside the container.
+
 ## GitHub Workflow
 
 Use the `hub` CLI (not `gh`) for all GitHub operations such as opening pull requests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_USER=${USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-automation-calculator-password}
       - POSTGRES_DB=${POSTGRES_DB:-automation-calculator-development}
-    image: postgres:13-alpine
+    image: postgres:16-alpine
     ports:
       - "5434:5432"
     volumes:

--- a/version_dates/key_gems.json
+++ b/version_dates/key_gems.json
@@ -1,0 +1,64 @@
+{
+  "nokogiri": {
+    "version": "1.14.1",
+    "release_date": "2023-02-06",
+    "source": "Gemfile.lock, Dockerfiles gem install nokogiri -v 1.14.1"
+  },
+  "pg": {
+    "version": "1.0.0",
+    "release_date": "2018-01-25",
+    "source": "Gemfile.lock"
+  },
+  "puma": {
+    "version": "4.3.12",
+    "release_date": "2022-03-09",
+    "source": "Gemfile.lock"
+  },
+  "devise": {
+    "version": "4.7.1",
+    "release_date": "2020-01-31",
+    "source": "Gemfile.lock"
+  },
+  "jwt": {
+    "version": "2.7.0",
+    "release_date": "2022-12-02",
+    "source": "Gemfile.lock"
+  },
+  "bootstrap": {
+    "version": "4.3.1",
+    "release_date": "2019-03-11",
+    "source": "Gemfile.lock"
+  },
+  "omniauth": {
+    "version": "1.9.2",
+    "release_date": "2020-08-05",
+    "source": "Gemfile.lock"
+  },
+  "omniauth_google_oauth2": {
+    "version": "0.8.2",
+    "source": "Gemfile.lock"
+  },
+  "omniauth_github": {
+    "version": "1.4.0",
+    "source": "Gemfile.lock"
+  },
+  "active_model_serializers": {
+    "version": "0.10.7",
+    "source": "Gemfile.lock"
+  },
+  "rspec_rails": {
+    "version": "3.7.2",
+    "release_date": "2018-06-29",
+    "source": "Gemfile.lock"
+  },
+  "rubocop": {
+    "version": "0.57.1",
+    "release_date": "2018-06-12",
+    "source": "Gemfile.lock"
+  },
+  "capybara": {
+    "version": "3.2.1",
+    "release_date": "2018-07-24",
+    "source": "Gemfile.lock"
+  }
+}

--- a/version_dates/linux.json
+++ b/version_dates/linux.json
@@ -1,0 +1,17 @@
+{
+  "debian": {
+    "codename": "Bullseye",
+    "version": "11",
+    "release_date": "2021-08-14",
+    "end_of_life": "2026-06-01",
+    "source": "Dockerfile.base FROM ruby:2.7.7-slim-bullseye",
+    "notes": "slim-bullseye is the minimal Debian 11 variant shipped with the official Ruby Docker image"
+  },
+  "openssl": {
+    "version": "1.1.1",
+    "series_release_date": "2016-09-11",
+    "series_end_of_life": "2023-09-11",
+    "debian_bullseye_package": "openssl 1.1.1n (or later 1.1.1 patch shipped with Bullseye updates)",
+    "notes": "OpenSSL 1.1.1 is the version bundled with Debian Bullseye; exact patch level depends on when the Docker image was pulled"
+  }
+}

--- a/version_dates/node.json
+++ b/version_dates/node.json
@@ -1,0 +1,15 @@
+{
+  "node": {
+    "major_version": "20",
+    "lts_codename": "Iron",
+    "lts_start_date": "2023-10-24",
+    "lts_end_date": "2026-04-30",
+    "source": "Dockerfiles: curl -sL https://deb.nodesource.com/setup_20.x",
+    "notes": "Exact minor/patch version is resolved at image build time from the NodeSource 20.x channel"
+  },
+  "yarn": {
+    "version": "latest at build time",
+    "source": "Dockerfiles: npm install -g yarn",
+    "notes": "Pinned to latest yarn via npm at image build; not locked to a specific version"
+  }
+}

--- a/version_dates/postgresql.json
+++ b/version_dates/postgresql.json
@@ -1,0 +1,11 @@
+{
+  "postgresql": {
+    "version": "16",
+    "variant": "Alpine",
+    "docker_image": "postgres:16-alpine",
+    "release_date": "2023-09-14",
+    "end_of_life": "2027-11-09",
+    "source": "docker-compose.yml",
+    "notes": "Used for local dev and CI; exact patch version resolved at image pull time"
+  }
+}

--- a/version_dates/rails.json
+++ b/version_dates/rails.json
@@ -1,0 +1,9 @@
+{
+  "rails": {
+    "version": "5.2.8.1",
+    "release_date": "2022-09-13",
+    "source": "Gemfile.lock",
+    "end_of_life": "2022-06-01",
+    "notes": "5.2.x EOL; 5.2.8.1 was a security patch release after the branch went unsupported"
+  }
+}

--- a/version_dates/ruby.json
+++ b/version_dates/ruby.json
@@ -1,0 +1,14 @@
+{
+  "ruby": {
+    "version": "2.7.7",
+    "release_date": "2022-11-24",
+    "source": ".ruby-version, Dockerfile.base FROM ruby:2.7.7-slim-bullseye",
+    "end_of_life": "2023-03-31",
+    "notes": "Security-only maintenance ended; EOL as of 2023-03-31"
+  },
+  "bundler": {
+    "version": "2.3.26",
+    "release_date": "2022-09-28",
+    "source": "Gemfile.lock BUNDLED WITH, Dockerfiles gem install bundler -v 2.3.26"
+  }
+}

--- a/version_dates/upgrade_path.json
+++ b/version_dates/upgrade_path.json
@@ -1,0 +1,110 @@
+{
+  "description": "Incremental upgrade path to modernize the repo. Each phase is designed to be mergeable independently to limit blast radius. Phases should be done in order — later phases depend on earlier ones.",
+  "phases": [
+    {
+      "phase": 1,
+      "name": "Rails 5.2 → 6.1",
+      "rationale": "Rails 6.1 is the last major version that still supports Ruby 2.7, making it the safest first step. Skipping 6.0 is intentional — 6.1 has better LTS-era gem support and a more complete upgrade guide.",
+      "ruby_version": "2.7.7 (unchanged)",
+      "changes": {
+        "rails": "5.2.8.1 → 6.1.x",
+        "rspec_rails": "3.7.2 → 5.x (Rails 6.1 requires rspec-rails 4+)",
+        "puma": "4.3.12 → 5.x (recommended for Rails 6.1; Puma 6 can wait)",
+        "pg": "1.0.0 → 1.5.x (long-overdue; no Rails-version dependency)",
+        "sprockets": "3.7.2 → 4.x (Rails 6.1 defaults to Sprockets 4)"
+      },
+      "known_risks": [
+        "Zeitwerk autoloader replaces classic autoloader — requires all files to follow naming conventions exactly",
+        "Action Mailer, ActiveRecord, and ActiveStorage APIs have deprecation removals between 5.2 and 6.1",
+        "sprockets 4 changes manifest.js format — assets:precompile behavior changes"
+      ]
+    },
+    {
+      "phase": 2,
+      "name": "Ruby 2.7.7 → 3.1.x + replace therubyracer",
+      "rationale": "Ruby 3.0 made keyword argument separation mandatory (no longer a warning). Ruby 3.1 is the minimum for the subsequent Rails upgrade. This phase also drops therubyracer, which does not build reliably on Ruby 3.x, replacing it with mini_racer.",
+      "rails_version": "6.1.x (unchanged)",
+      "changes": {
+        "ruby": "2.7.7 → 3.1.x",
+        "docker_base_image": "ruby:2.7.7-slim-bullseye → ruby:3.1.x-slim-bullseye",
+        "therubyracer": "remove (incompatible with Ruby 3.x)",
+        "mini_racer": "add ~> 0.6 (ExecJS runtime replacement for therubyracer)",
+        "bundler": "2.3.26 → 2.4.x (ships with Ruby 3.1)"
+      },
+      "known_risks": [
+        "therubyracer removal can break asset compilation if mini_racer is not added — test assets:precompile explicitly",
+        "Ruby 3.0 keyword argument changes (hash-as-kwargs) can cause ArgumentError in app and gem code — run full test suite and watch for failures",
+        "coffee-rails still works but CoffeeScript is end-of-life; no urgent action required yet"
+      ]
+    },
+    {
+      "phase": 3,
+      "name": "Linux Bullseye → Bookworm (OpenSSL 1.1.1 → 3.0)",
+      "rationale": "Debian Bookworm (12) ships with OpenSSL 3.0, which is actively maintained. OpenSSL 1.1.1 reached end-of-life in September 2023. Separating the OS bump from Ruby/Rails upgrades makes it easy to bisect if anything breaks.",
+      "ruby_version": "3.1.x (unchanged)",
+      "rails_version": "6.1.x (unchanged)",
+      "changes": {
+        "docker_base_image": "ruby:3.1.x-slim-bullseye → ruby:3.1.x-slim-bookworm",
+        "openssl": "1.1.1 → 3.0.x"
+      },
+      "known_risks": [
+        "OpenSSL 3.0 deprecates legacy cryptographic algorithms — if any OAuth or JWT configuration uses weak algorithms (MD5, RC4, etc.) it will fail",
+        "System library package names occasionally differ between Bullseye and Bookworm — verify apt-get install lines in all Dockerfiles still resolve"
+      ]
+    },
+    {
+      "phase": 4,
+      "name": "Rails 6.1 → 7.0 + omniauth 1 → 2",
+      "rationale": "Rails 7.0 introduces Hotwire as the default and removes several long-deprecated APIs. omniauth 2.x must be addressed here because it drops GET-based OAuth callbacks (CSRF fix) — the integration with Devise and Google/GitHub strategies requires explicit adapter gems.",
+      "ruby_version": "3.1.x (unchanged)",
+      "changes": {
+        "rails": "6.1.x → 7.0.x",
+        "omniauth": "1.9.2 → 2.x",
+        "omniauth_google_oauth2": "0.8.2 → 1.x (2.x-compatible release)",
+        "omniauth_github": "1.4.0 → 2.x",
+        "omniauth_rails_csrf_protection": "add ~> 1.0 (required adapter for omniauth 2 + Rails)",
+        "rspec_rails": "5.x → 6.x",
+        "sass_rails": "consider migration to dartsass-rails (sassc-based sass-rails is unmaintained)"
+      },
+      "known_risks": [
+        "omniauth 2.x rejects GET /auth/:provider — all OAuth flows must use POST; Devise's OmniAuth integration may need omniauth-rails_csrf_protection gem",
+        "Rails 7.0 removes several ActiveRecord and ActionView helpers removed in 6.x deprecation cycle",
+        "sass-rails 5.x is effectively unmaintained; dartsass-rails is a drop-in replacement but uses a different sass binary"
+      ]
+    },
+    {
+      "phase": 5,
+      "name": "Ruby 3.1 → 3.2 + Rails 7.0 → 7.1",
+      "rationale": "Ruby 3.2 adds significant performance improvements (YJIT stable) and Prism parser. Rails 7.1 pairs naturally with Ruby 3.2 and adds native async queries, better error pages, and Trilogy adapter support. Doing them together is low-risk since 7.1 explicitly targets 3.2.",
+      "changes": {
+        "ruby": "3.1.x → 3.2.x",
+        "rails": "7.0.x → 7.1.x",
+        "docker_base_image": "ruby:3.1.x-slim-bookworm → ruby:3.2.x-slim-bookworm",
+        "puma": "5.x → 6.x"
+      },
+      "known_risks": [
+        "Rails 7.1 changes the default serialization format for encrypted attributes — if any model uses encrypts, existing ciphertext may be unreadable without a migration",
+        "Ruby 3.2 removes some long-deprecated features (e.g. rb_cData C API) that may affect native gems like pg — verify gem compatibility before upgrading"
+      ]
+    },
+    {
+      "phase": 6,
+      "name": "Rails 7.1 → 7.2 or 8.0 (long-term target)",
+      "rationale": "Rails 7.2 requires Ruby 3.1+ (already satisfied). Rails 8.0 ships Solid Cache, Solid Queue, and Solid Cable as first-class options and drops several legacy defaults. This phase is exploratory — evaluate based on ecosystem readiness at the time.",
+      "changes": {
+        "rails": "7.1.x → 7.2.x or 8.0.x",
+        "ruby": "3.2.x (minimum; 3.3.x recommended for 8.0)"
+      },
+      "known_risks": [
+        "Rails 8.0 removes Sprockets as the default asset pipeline in favor of Propshaft — CoffeeScript migration to plain JS would become necessary at this point",
+        "Review all gem dependencies for Rails 8 compatibility before upgrading; the ecosystem lagged on 7.0 and 7.1 upgrades historically"
+      ]
+    }
+  ],
+  "standing_notes": [
+    "CoffeeScript (coffee-rails 4.2.2) is EOL. A migration to plain JavaScript can be done independently of any Rails or Ruby upgrade, and would reduce future risk significantly.",
+    "Bootstrap 4.3.1 → 5.x is a separate, design-breaking migration (grid and utility class renames) and is not included in this path. It should be scoped as a standalone UI project.",
+    "rubocop 0.57.1 is very old (2018). Each phase should include a rubocop version bump as a secondary task since new cops will flag newly introduced code.",
+    "PostgreSQL 16 is already current. PostgreSQL 17 can be adopted opportunistically when the Alpine image becomes stable, with no major compatibility concerns expected."
+  ]
+}


### PR DESCRIPTION
## Changes

- Adds `version_dates/` directory with JSON files capturing current versions and release/EOL dates for Ruby, Rails, Debian Bullseye, OpenSSL, Node 20, PostgreSQL, and key gems (nokogiri, puma, devise, jwt, bootstrap, omniauth, rspec-rails, rubocop, capybara, etc.)
- Bumps dev Postgres Docker image from `postgres:13-alpine` to `postgres:16-alpine` in `docker-compose.yml`
- Documents in `CLAUDE.md` that CI handles image builds and test runs for Dockerfile changes, so test plans only need to cover what CI cannot verify

## Test plan

- CI will build the image and run the full RSpec suite against Postgres 16
- Verify `./go start` comes up cleanly with the new Postgres image locally if testing the DB bump manually