### PR TITLE
Phase 4: Rails 6.1 → 7.0 + omniauth 1 → 2

### DIFF
--- a/version_dates/phase_4_tracking.json
+++ b/version_dates/phase_4_tracking.json
@@ -1,0 +1,15 @@
+{
+  "phase": 4,
+  "name": "Rails 6.1 → 7.0 + omniauth 1 → 2",
+  "status": "not_started",
+  "ruby_version": "3.1.x (unchanged, applied after Phase 2)",
+  "changes": {
+    "rails": "6.1.x → 7.0.x",
+    "omniauth": "1.9.2 → 2.x",
+    "omniauth_google_oauth2": "0.8.2 → 1.x",
+    "omniauth_github": "1.4.0 → 2.x",
+    "omniauth_rails_csrf_protection": "add ~> 1.0 (required for omniauth 2 + Rails)",
+    "rspec_rails": "5.x → 6.x",
+    "sass_rails": "consider migration to dartsass-rails"
+  }
+}


### PR DESCRIPTION
## Overview

Upgrade Rails to 7.0 and simultaneously upgrade omniauth from 1.x to 2.x. These are bundled together because omniauth 2.x drops GET-based OAuth callbacks (a CSRF fix) and requires `omniauth-rails_csrf_protection` as an adapter with Devise — it's cleanest to land that alongside the Rails 7.0 upgrade rather than as a separate mid-phase change.

Depends on Phases 1, 2, and 3 being merged first.

## Changes

- **rails** 6.1.x → 7.0.x
- **omniauth** 1.9.2 → 2.x
- **omniauth-google-oauth2** 0.8.2 → 1.x (2.x-compatible release)
- **omniauth-github** 1.4.0 → 2.x
- **omniauth-rails_csrf_protection** add ~> 1.0 (required adapter for omniauth 2 + Rails)
- **rspec-rails** 5.x → 6.x
- **sass-rails** evaluate migration to `dartsass-rails` (sass-rails is unmaintained)

## Known Risks

- omniauth 2.x rejects GET `/auth/:provider` — all OAuth flows must use POST; the Devise integration needs `omniauth-rails_csrf_protection` wired in `config/initializers/devise.rb`
- Rails 7.0 removes several helpers deprecated in 6.x — run the full suite and check for `NoMethodError` on removed APIs
- `sass-rails` 5.x uses `sassc` which is unmaintained; `dartsass-rails` is the drop-in replacement but uses a separate binary

## Test Plan

- CI will run the full RSpec suite
- Manually test Google OAuth and GitHub OAuth login flows end-to-end — these are the highest-risk area given the omniauth 2 CSRF change

## Upgrade Guide

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-6-1-to-rails-7-0
https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0

Part of the modernization plan in `version_dates/upgrade_path.json`.