### PR TITLE
Phase 5: Ruby 3.1 → 3.2 + Rails 7.0 → 7.1

### DIFF
--- a/version_dates/phase_5_tracking.json
+++ b/version_dates/phase_5_tracking.json
@@ -1,0 +1,12 @@
+{
+  "phase": 5,
+  "name": "Ruby 3.1 → 3.2 + Rails 7.0 → 7.1",
+  "status": "not_started",
+  "note": "Ruby and Rails bumped together — 7.1 explicitly targets Ruby 3.2 and the pairing is low-risk",
+  "changes": {
+    "ruby": "3.1.x → 3.2.x",
+    "rails": "7.0.x → 7.1.x",
+    "docker_base_image": "ruby:3.1.x-slim-bookworm → ruby:3.2.x-slim-bookworm",
+    "puma": "5.x → 6.x"
+  }
+}


### PR DESCRIPTION
## Overview

Bump Ruby to 3.2 and Rails to 7.1 together — Rails 7.1 explicitly targets Ruby 3.2 and the pairing is well-tested in the ecosystem. Ruby 3.2 brings stable YJIT and the Prism parser. Puma also moves to 6.x here.

Depends on Phases 1–4 being merged first.

## Changes

- **ruby** 3.1.x → 3.2.x
- **rails** 7.0.x → 7.1.x
- **docker base image** `ruby:3.1.x-slim-bookworm` → `ruby:3.2.x-slim-bookworm`
- **puma** 5.x → 6.x

## Known Risks

- Rails 7.1 changes the default serialization format for encrypted attributes — if any model uses `encrypts`, existing ciphertext may be unreadable without a migration (not currently used in this app, but verify)
- Ruby 3.2 removes some deprecated C API internals — verify native gems (`pg`, `mini_racer`) are compatible before upgrading

## Test Plan

- CI will build the Ruby 3.2 image and run the full RSpec suite
- Spot-check the scenario creation and break-even chart flows manually after the upgrade

## Upgrade Guide

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-7-0-to-rails-7-1

Part of the modernization plan in `version_dates/upgrade_path.json`.