### PR TITLE
Phase 6: Rails 7.1 → 7.2 or 8.0 (long-term target)

### DIFF
--- a/version_dates/phase_6_tracking.json
+++ b/version_dates/phase_6_tracking.json
@@ -1,0 +1,12 @@
+{
+  "phase": 6,
+  "name": "Rails 7.1 → 7.2 or 8.0 (long-term target)",
+  "status": "not_started",
+  "note": "Exploratory — evaluate based on ecosystem readiness at the time. Rails 8.0 drops Sprockets as default, which forces CoffeeScript migration.",
+  "changes": {
+    "rails": "7.1.x → 7.2.x or 8.0.x",
+    "ruby": "3.2.x minimum; 3.3.x recommended for 8.0",
+    "coffee_rails": "remove — Sprockets no longer default in Rails 8.0, CoffeeScript migration to plain JS required",
+    "asset_pipeline": "Sprockets → Propshaft (if targeting Rails 8.0)"
+  }
+}


### PR DESCRIPTION
## Overview

The long-term modernization target. Rails 8.0 ships Solid Cache, Solid Queue, and Solid Cable as first-class defaults and removes Sprockets as the default asset pipeline in favor of Propshaft. Removing Sprockets makes the CoffeeScript migration from `coffee-rails` to plain JavaScript a hard requirement at this phase.

Depends on Phases 1–5 being merged first. Evaluate whether to target 7.2 or go straight to 8.0 based on ecosystem readiness when this phase begins.

## Changes

- **rails** 7.1.x → 7.2.x or 8.0.x
- **ruby** 3.2.x (minimum); 3.3.x recommended if targeting Rails 8.0
- **coffee-rails** removed — CoffeeScript migration to plain JS required before or alongside this phase
- **asset pipeline** Sprockets → Propshaft (if targeting Rails 8.0)

## Known Risks

- Rails 8.0 removes Sprockets as the default — migrating CoffeeScript (`automation_scenarios.coffee`) to plain JavaScript is a prerequisite, not optional
- The ecosystem historically lags 3–6 months on major Rails version gem compatibility — audit all gems before upgrading
- Solid Queue / Solid Cache are opt-in; no action required unless adopting them

## Test Plan

- CI will run the full RSpec suite
- Full manual smoke test of the app after migration: sign in, create a scenario, verify the Plotly chart renders (JavaScript asset compilation is the highest risk area here)

## Upgrade Guide

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-7-1-to-rails-7-2

Part of the modernization plan in `version_dates/upgrade_path.json`.