### PR TITLE
Add DB connection check to /health endpoint

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,8 +1,19 @@
 class HealthCheckController < ApplicationController
   def health
+    db_ok = database_reachable?
     render json: {
       current_time_in_unix: Time.current.to_i,
-      short_commit_hash: ENV['SHORT_COMMIT_HASH']
-    }
+      short_commit_hash: ENV['SHORT_COMMIT_HASH'],
+      database: db_ok ? 'ok' : 'unavailable'
+    }, status: db_ok ? :ok : :service_unavailable
+  end
+
+  private
+
+  def database_reachable?
+    ActiveRecord::Base.connection.execute('SELECT 1')
+    true
+  rescue StandardError
+    false
   end
 end

--- a/spec/controllers/health_check_controller_spec.rb
+++ b/spec/controllers/health_check_controller_spec.rb
@@ -1,22 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe HealthCheckController, type: :controller do
-  def expected_response
-    {
-      current_time_in_unix: Time.current.to_i,
-      short_commit_hash: ENV['SHORT_COMMIT_HASH']
-    }.to_json
-  end
-
   describe '#health' do
-    it 'returns response in json format' do
-      get :health
-      expect(response.content_type).to eq('application/json')
+    context 'when the database is reachable' do
+      it 'returns 200' do
+        get :health
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns json content type' do
+        get :health
+        expect(response.content_type).to eq('application/json')
+      end
+
+      it 'returns timestamp, commit hash, and database ok' do
+        get :health
+        body = JSON.parse(response.body)
+        expect(body['current_time_in_unix']).to be_a(Integer)
+        expect(body['short_commit_hash']).to eq(ENV['SHORT_COMMIT_HASH'])
+        expect(body['database']).to eq('ok')
+      end
     end
 
-    it 'returns git commit hash and unix timestamp' do
-      get :health
-      expect(response.body).to eq(expected_response)
+    context 'when the database is unreachable' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(PG::ConnectionBad)
+      end
+
+      it 'returns 503' do
+        get :health
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
+      it 'returns database unavailable without sensitive details' do
+        get :health
+        body = JSON.parse(response.body)
+        expect(body['database']).to eq('unavailable')
+        expect(response.body).not_to match(/host|password|user|dbname|connect/i)
+      end
     end
   end
 end

--- a/spec/controllers/health_check_controller_spec.rb
+++ b/spec/controllers/health_check_controller_spec.rb
@@ -13,18 +13,29 @@ RSpec.describe HealthCheckController, type: :controller do
         expect(response.content_type).to eq('application/json')
       end
 
-      it 'returns timestamp, commit hash, and database ok' do
+      it 'returns a unix timestamp' do
         get :health
         body = JSON.parse(response.body)
         expect(body['current_time_in_unix']).to be_a(Integer)
+      end
+
+      it 'returns the short commit hash' do
+        get :health
+        body = JSON.parse(response.body)
         expect(body['short_commit_hash']).to eq(ENV['SHORT_COMMIT_HASH'])
+      end
+
+      it 'returns database ok' do
+        get :health
+        body = JSON.parse(response.body)
         expect(body['database']).to eq('ok')
       end
     end
 
     context 'when the database is unreachable' do
       before do
-        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(PG::ConnectionBad)
+        allow(ActiveRecord::Base.connection).to receive(:execute)
+          .and_raise(PG::ConnectionBad)
       end
 
       it 'returns 503' do
@@ -32,10 +43,14 @@ RSpec.describe HealthCheckController, type: :controller do
         expect(response).to have_http_status(:service_unavailable)
       end
 
-      it 'returns database unavailable without sensitive details' do
+      it 'returns database unavailable' do
         get :health
         body = JSON.parse(response.body)
         expect(body['database']).to eq('unavailable')
+      end
+
+      it 'does not leak sensitive connection details' do
+        get :health
         expect(response.body).not_to match(/host|password|user|dbname|connect/i)
       end
     end


### PR DESCRIPTION
## Summary

- `GET /health` now checks the database connection before responding
- Returns **503** if the database is unreachable; **200** if healthy
- Response body includes `"database": "ok"` or `"database": "unavailable"` — no connection string, host, credentials, or exception details are included in the response

## Test plan

CI will run the full suite including the updated `HealthCheckController` spec, which covers both the happy path (200 + `database: ok`) and the failure path (503 + `database: unavailable`, no sensitive strings in body).