### PR TITLE
Fix and complete ./go help text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ All commands run via the `./go` script (a Ruby dispatcher into `scripts/`):
 ./go lint              # Run RuboCop in Docker
 ./go shell             # Open a shell in the dev container
 ./go stop              # Stop containers
+./go restart           # Stop and restart the dev environment
 ./go clean             # Remove all containers, images, volumes
 ./go build             # Rebuild Docker images (required after Gemfile changes)
 ./go db dev            # Connect to PostgreSQL with psql

--- a/scripts/database_terminal.rb
+++ b/scripts/database_terminal.rb
@@ -11,7 +11,7 @@ class DatabaseTerminal
       if COMMAND_HASH.key? sub_cmd.to_sym
         COMMAND_HASH[sub_cmd.to_sym].call
       else
-        HelpText.help(['shell'])
+        HelpText.help(['db'])
         puts
         warn("Unrecognized command: #{sub_cmd}")
       end

--- a/scripts/help_text.rb
+++ b/scripts/help_text.rb
@@ -6,21 +6,24 @@ class HelpText
         '[Default] Build docker containers for your development environment.',
       ci: 'Build docker containers to simulate the ci environment.'
     }.freeze,
+    clean: 'Remove all containers, images, and volumes (full reset).',
     db: {
       dev:
         '[Default] Connect to the application\'s database ' \
         'in the development environment with psql'
     }.freeze,
     create_host: 'Create a docker-machine host for the application.',
-    init: 'Setup your development environment with docker.',
+    init: 'First-time setup: build images and run database setup.',
+    logs: 'Tail logs from the dev container.',
     push:
       'Push docker image to docker hub. ' \
       'Useful for debugging when CI fails to do this properly.',
     lint:
       'Use a linter on the application ' \
       'and test code to ensure code style is consistent.',
-    rm: 'Remove running or stopped docker containers for a clean restart.',
-    rmi: 'Remove the development docker image. ',
+    restart: 'Stop and restart the dev environment.',
+    rm: 'Stop and remove all docker containers.',
+    rmi: 'Remove the development docker image.',
     shell: {
       dev: '[Default] Open a terminal inside of the development container.',
       production: 'Open a terminal container with the production image.'
@@ -39,7 +42,7 @@ class HelpText
     tag:
       'Tag CI\'s docker image with semver. ' \
       'Useful for debugging when CI fails to do this properly.',
-    test: 'Run all tests in the docker containers.'
+    test: 'Run the RSpec test suite in docker.'
   }.freeze
 
   class << self


### PR DESCRIPTION
- Add missing help entries for `clean`, `logs`, and `restart` (all registered commands that had no help)
- Fix bug in `database_terminal.rb` where an unrecognized `db` subcommand showed `shell` help instead of `db` help
- Tighten descriptions for `init`, `rm`, `rmi`, and `test` to be more accurate