### PR TITLE
Add ci subcommand to ./go shell

### DIFF
--- a/scripts/help_text.rb
+++ b/scripts/help_text.rb
@@ -42,6 +42,7 @@ class HelpText
     rm: 'Remove running or stopped docker containers for a clean restart.',
     rmi: 'Remove the development docker image.',
     shell: {
+      ci: 'Open a terminal inside of the CI container.',
       dev: '[Default] Open a terminal inside of the development container.',
       production: 'Open a terminal container with the production image.'
     }.freeze,

--- a/scripts/shell.rb
+++ b/scripts/shell.rb
@@ -3,6 +3,7 @@ require './scripts/utils/get_uid.rb'
 
 class Shell
   COMMAND_HASH = {
+    ci: -> { ci_shell },
     dev: -> { dev_shell },
     production: -> { production_shell }
   }.freeze
@@ -18,6 +19,14 @@ class Shell
         puts
         warn("Unrecognized command: #{sub_cmd}")
       end
+    end
+
+    def ci_shell
+      exec(
+        "USER=#{ENV.fetch('USER', 'circleci')} docker compose -f docker-compose.yml" \
+        ' -f docker-compose.ci.yml' \
+        ' run --entrypoint /bin/bash ci'
+      )
     end
 
     def dev_shell


### PR DESCRIPTION
Adds `./go shell ci` to open a terminal inside the CI container, using the same `docker-compose.ci.yml` compose file that CI uses. Also adds the corresponding help text entry.