### PR TITLE
Fix CI tests using stale Docker image with old pg gem

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,6 +1,6 @@
 services:
   ci:
-    image: automationcalculator/automation-calculator-rails:latest
+    image: automationcalculationsci/automation-calculator:latest
     depends_on:
       - db
     command: rspec


### PR DESCRIPTION
docker-compose.ci.yml pointed to `automationcalculator/automation-calculator-rails:latest` — a stale image in the wrong Docker Hub org — instead of `automationcalculationsci/automation-calculator:latest`, which is what `./go build ci` actually produces.

As a result, CI was running with pg 0.21.0 built against old libpq, which fails SCRAM auth against PostgreSQL 16.