### PR TITLE
Restore ENV['USER'] fallback for ./go build dev on macOS

### DIFF
--- a/scripts/docker_build.rb
+++ b/scripts/docker_build.rb
@@ -44,7 +44,7 @@ class DockerBuild
       build_image(
         'automation-calculator_dev',
         'Dockerfile.development',
-        ENV['USERNAME'],
+        ENV['USERNAME'] || ENV['USER'],
         additional_build_arg: "--build-arg uid=#{GetUID.read_uid}",
         no_cache: no_cache,
         multi_platform: multi_platform


### PR DESCRIPTION
## Summary
- Restore the `ENV['USERNAME'] || ENV['USER']` fallback in `scripts/docker_build.rb#build_dev_image` so `./go build dev` works on macOS.
- PR #189 (cf8f36d) added this fallback originally; PR #191 (5a67ef5 "Extracting go script updates from base image branch…") reverted it while pulling in unrelated changes.
- Without the fallback, Ruby's `ENV['USERNAME']` is `nil` on macOS, the `--build-arg username=` is empty, and `RUN useradd --uid=$uid -ms /bin/bash $username` in `Dockerfile.development` exits 2.

## Test plan
- [x] `./go build dev` completes successfully on macOS with this fix
- [ ] Confirm CI still passes (Linux CI uses `'circleci'` literal for username, so unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)