### PR TITLE
Fix ./go smoke staging failures

### DIFF
--- a/spec/smoke/visitor_api_flow_spec.rb
+++ b/spec/smoke/visitor_api_flow_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe 'Visitor API flow', :smoke do
         body: { name: 'smoke-test', iteration_count: 100 },
         token: token
       ).tap do |r|
-        msg = "Expected 201 creating scenario, got #{r.code}: #{r.body}"
-        expect(r.code.to_i).to eq(201), msg
+        msg = "Expected 200 creating scenario, got #{r.code}: #{r.body}"
+        expect(r.code.to_i).to eq(200), msg
       end
     end
 
@@ -70,9 +70,10 @@ RSpec.describe 'Visitor API flow', :smoke do
   end
 
   describe 'break-even math' do
-    # manual:    $0 upfront, $10/iteration  -> cost(n) = 10n
-    # automated: $100 upfront, $2/iteration -> cost(n) = 100 + 2n
-    # intersection: 10n = 100 + 2n  ->  n = 12.5, cost = 125.0
+    # initial_cost must be > 0 (Solution model validation).
+    # manual:    $10 upfront, $10/iteration  -> cost(n) = 10 + 10n
+    # automated: $110 upfront, $2/iteration  -> cost(n) = 110 + 2n
+    # intersection: 8n = 100  ->  n = 12.5, cost = 135.0
     let(:scenario_id) do
       response = smoke_v1_post(
         '/api/automation_scenarios',
@@ -85,12 +86,12 @@ RSpec.describe 'Visitor API flow', :smoke do
     before do
       smoke_v1_post(
         "/api/automation_scenarios/#{scenario_id}/solutions",
-        body: { initial_cost: 0, iteration_cost: 10 },
+        body: { initial_cost: 10, iteration_cost: 10 },
         token: token
       )
       smoke_v1_post(
         "/api/automation_scenarios/#{scenario_id}/solutions",
-        body: { initial_cost: 100, iteration_cost: 2 },
+        body: { initial_cost: 110, iteration_cost: 2 },
         token: token
       )
     end
@@ -127,7 +128,7 @@ RSpec.describe 'Visitor API flow', :smoke do
       point = intersections.first&.fetch('intersection')
       expect(point).not_to be_nil, 'Expected at least one intersection'
       expect(point[0].to_f).to be_within(0.01).of(12.5)
-      expect(point[1].to_f).to be_within(0.01).of(125.0)
+      expect(point[1].to_f).to be_within(0.01).of(135.0)
     end
   end
 end

--- a/spec/smoke_helper.rb
+++ b/spec/smoke_helper.rb
@@ -45,7 +45,11 @@ module SmokeSchema
 
   def validate_schema!(schema_name, body)
     data = body.is_a?(String) ? JSON.parse(body) : body
-    valid, errors = schema_store.find("file:/#{schema_name}#").validate(data)
+    # JsonSchema normalizes id "file:/foo.json#" to URI "file:///foo.json".
+    schema = schema_store.lookup_schema("file:///#{schema_name}")
+    raise "Schema not loaded: #{schema_name}" if schema.nil?
+
+    valid, errors = schema.validate(data)
     return if valid
 
     raise "Schema mismatch for #{schema_name}: " \

--- a/spec/support/api_schemas/automation_scenarios.json
+++ b/spec/support/api_schemas/automation_scenarios.json
@@ -1,4 +1,5 @@
 {
+  "id": "file:/automation_scenarios.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
   "items": {

--- a/spec/support/api_schemas/solution_differences.json
+++ b/spec/support/api_schemas/solution_differences.json
@@ -1,4 +1,5 @@
 {
+  "id": "file:/solution_differences.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
   "items": {

--- a/spec/support/api_schemas/solution_intersections.json
+++ b/spec/support/api_schemas/solution_intersections.json
@@ -1,4 +1,5 @@
 {
+  "id": "file:/solution_intersections.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
   "items": {

--- a/spec/support/api_schemas/solutions.json
+++ b/spec/support/api_schemas/solutions.json
@@ -1,4 +1,5 @@
 {
+  "id": "file:/solutions.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
   "items": {

--- a/spec/support/api_schemas/user.json
+++ b/spec/support/api_schemas/user.json
@@ -1,4 +1,5 @@
 {
+  "id": "file:/user.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": ["id", "email"],

--- a/spec/support/api_schemas/visitor.json
+++ b/spec/support/api_schemas/visitor.json
@@ -1,4 +1,5 @@
 {
+  "id": "file:/visitor.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": ["id", "ip", "uuid"],


### PR DESCRIPTION
## Summary

`./go smoke staging` was failing 8/27 against the latest deploy. Root causes (all in test code; no app behavior changed):

- **Schema validator never worked.** `spec/smoke_helper.rb` called `schema_store.find(uri)`, but `JsonSchema::DocumentStore` has only `add_schema/lookup_schema/each` — `find` was hitting `Enumerable#find` and returning an `Enumerator`, so `.validate` raised `NoMethodError` on every schema check.
- **Plural schemas had no `id`.** `automation_scenarios.json`, `solution_intersections.json`, `solution_differences.json`, `solutions.json`, plus `user.json`/`visitor.json`, all lacked a top-level `id`, so they couldn't be looked up at all. Added the canonical `id` to each. The gem normalizes `"file:/foo.json#"` to URI `"file:///foo.json"`, so the helper now uses the normalized form.
- **`initial_cost: 0` was rejected.** `Solution` validates `initial_cost > 0` (`app/models/solution.rb:5`). The break-even math test silently 422'd creating its first solution, leaving an empty intersections array. Bumped to `(10, 10)` and `(110, 2)` → still `n = 12.5`, cost `135.0`; updated the assertion accordingly.
- **`POST /api/automation_scenarios` returns 200, not 201.** The controller renders without an explicit status, and the existing request specs assert `:ok` (`spec/requests/api/v1/automation_scenarios_controller_spec.rb:142`). Aligned the smoke assertion with the deployed contract rather than changing the API.

## Test plan

- [x] `./go smoke staging` — 27 examples, 0 failures
- [x] `./go test` — 323 examples, 0 failures, 6 pending (pre-existing)
- [x] `./go lint` — 148 files, no offenses
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)