### PR TITLE
Label Docker images with git short SHA

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -27,3 +27,6 @@ COPY --chown=$username Gemfile.lock $appdir/Gemfile.lock
 WORKDIR $appdir
 RUN bundle install
 #RUN rm $appdir/Gemfile.lock
+
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision=$GIT_COMMIT

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,3 +6,6 @@ WORKDIR /usr/src/app
 RUN bundle install --frozen
 
 RUN bundle exec rake assets:precompile
+
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision=$GIT_COMMIT

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -29,3 +29,6 @@ WORKDIR $appdir
 #Calling bundle install in image creation to install dependencies,
 # and also so that important bundle installed bins are in /usr/local/bundle/bin and thus in PATH variable for users.
 RUN bundle install
+
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision=$GIT_COMMIT

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -33,8 +33,11 @@ ENV SECRET_KEY_BASE="dummy"
 RUN rake assets:precompile
 ENV SECRET_KEY_BASE=""
 
-#Set this var to a reasonable default value, to be overridden per environment 
+#Set this var to a reasonable default value, to be overridden per environment
 ENV APP_HOSTNAME="automation-calculations.net"
+
+ARG GIT_COMMIT=unknown
+LABEL org.opencontainers.image.revision=$GIT_COMMIT
 
 ENTRYPOINT [ "/usr/src/app/entrypoint.sh" ]
 

--- a/scripts/docker_build.rb
+++ b/scripts/docker_build.rb
@@ -1,5 +1,6 @@
 # Build docker images for different environments
 require './scripts/utils/get_uid.rb'
+require './scripts/utils/git_short_sha.rb'
 
 class DockerBuild
   DOCKER_ORG = 'automationcalculationsci'.freeze
@@ -23,6 +24,7 @@ class DockerBuild
         "#{DOCKER_ORG}/automation-calculator-base:0.5.4",
         'Dockerfile.base',
         'circleci',
+        additional_build_arg: "--build-arg GIT_COMMIT=#{GitShortSha.read}",
         no_cache: no_cache,
         multi_platform: multi_platform
       )
@@ -35,6 +37,7 @@ class DockerBuild
         image,
         'Dockerfile.ci',
         'circleci',
+        additional_build_arg: "--build-arg GIT_COMMIT=#{GitShortSha.read}",
         no_cache: no_cache,
         multi_platform: multi_platform
       )
@@ -45,7 +48,8 @@ class DockerBuild
         'automation-calculator_dev',
         'Dockerfile.development',
         ENV['USERNAME'] || ENV['USER'],
-        additional_build_arg: "--build-arg uid=#{GetUID.read_uid}",
+        additional_build_arg: "--build-arg uid=#{GetUID.read_uid} " \
+                              "--build-arg GIT_COMMIT=#{GitShortSha.read}",
         no_cache: no_cache,
         multi_platform: multi_platform
       )
@@ -58,6 +62,7 @@ class DockerBuild
         image,
         'Dockerfile.production',
         'circleci',
+        additional_build_arg: "--build-arg GIT_COMMIT=#{GitShortSha.read}",
         no_cache: no_cache,
         multi_platform: multi_platform
       )

--- a/scripts/docker_hub.rb
+++ b/scripts/docker_hub.rb
@@ -60,7 +60,8 @@ class DockerHub
       system(
         "docker buildx build --platform #{DockerBuild::MULTI_PLATFORMS} " \
         "#{tags_flags} -f #{config[:file]} " \
-        "--build-arg username=#{config[:username]} --push .",
+        "--build-arg username=#{config[:username]} " \
+        "--build-arg GIT_COMMIT=#{GitShortSha.read} --push .",
         exception: true
       )
     end

--- a/scripts/utils/git_short_sha.rb
+++ b/scripts/utils/git_short_sha.rb
@@ -1,0 +1,8 @@
+class GitShortSha
+  class << self
+    def read
+      sha = `git rev-parse --short HEAD 2>/dev/null`.strip
+      sha.empty? ? 'unknown' : sha
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `org.opencontainers.image.revision` label (set to the short git SHA) to `Dockerfile.base`, `Dockerfile.ci`, `Dockerfile.development`, and `Dockerfile.production`.
- `./go build {base,ci,dev,prod}` now passes `--build-arg GIT_COMMIT=$(git rev-parse --short HEAD)`; falls back to `unknown` if git isn't reachable. The `--multi-platform` push path in `scripts/docker_hub.rb` is wired the same way.
- New `scripts/utils/git_short_sha.rb` helper, mirroring the existing `get_uid.rb` pattern.

## Motivation
core-iac (and anyone else inspecting a published image) had no way to determine the source commit of a built image — tags are semver-only. With the label, the commit can be read at deploy time without consulting the registry-side build log:

```bash
docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
  automationcalculationsci/automation-calculator:<tag>
```

## Test plan
- [ ] `./go build base` and confirm `docker inspect ... -base:0.5.4` shows a real short SHA in the label (not `unknown`).
- [ ] `./go build ci` and confirm the label on the resulting `:latest` image.
- [ ] `./go build dev` and confirm the label on `automation-calculator_dev`.
- [ ] `./go build prod` and confirm the label on the resulting `:latest` image.
- [ ] CI (`./go build prod` step) produces an image whose label matches `CIRCLE_SHA1[0..6]` for the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)