### PR TITLE
Fix smoke tests to expect 201 from scenario creation

### DIFF
--- a/spec/smoke/visitor_api_flow_spec.rb
+++ b/spec/smoke/visitor_api_flow_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe 'Visitor API flow', :smoke do
         body: { name: 'smoke-test', iteration_count: 100 },
         token: token
       ).tap do |r|
-        msg = "Expected 200 creating scenario, got #{r.code}: #{r.body}"
-        expect(r.code.to_i).to eq(200), msg
+        msg = "Expected 201 creating scenario, got #{r.code}: #{r.body}"
+        expect(r.code.to_i).to eq(201), msg
       end
     end
 


### PR DESCRIPTION
## Summary
- PR #203 changed `POST /api/automation_scenarios` to render with `status: :created` (201), but `spec/smoke/visitor_api_flow_spec.rb` still asserted 200.
- That mismatch is why `./go smoke prod` fails (prod runs the new code returning 201) while `./go smoke staging` passes (staging still on the old code returning 200).
- Align the smoke assertion with the controller's actual response and the request spec's `:created` expectation.

## Test plan
- [ ] `./go smoke prod` passes
- [ ] `./go smoke staging` passes after staging redeploys with the 201 controller change